### PR TITLE
add format for host paraemters

### DIFF
--- a/lib/xsub/schedulers/fx10.rb
+++ b/lib/xsub/schedulers/fx10.rb
@@ -16,11 +16,11 @@ LANG=C
 EOS
 
     PARAMETERS = {
-      "mpi_procs" => { description: "MPI process", default: 1},
-      "omp_threads" => { description: "OMP threads", default: 1},
-      "elapse" => { description: "Limit on elapsed time", default: "1:00:00"},
-      "node" => { description: "Nodes", default: "1"},
-      "shape" => { description: "Shape", default: "1"}
+      "mpi_procs" => { description: "MPI process", default: 1, format: "^([1-9]|[1-9][\\d]+)$"},
+      "omp_threads" => { description: "OMP threads", default: 1, format: "^([1-9]|[1-9][\\d]+)$"},
+      "elapse" => { description: "Limit on elapsed time", default: "1:00:00", format: "^([01]?[0-9]|2[0-4]):([0-5][\\d]):([0-5][\\d])$"},
+      "node" => { description: "Nodes", default: "1", format: "^([1-9]|[1-9][\\d]+)$|^([1-9]|[1-9][\\d]+)x([1-9]|[1-9][\\d]+)$|^([1-9]|[1-9][\\d]+)x([1-9]|[1-9][\\d]+)x([1-9]|[1-9][\\d]+)$"},
+      "shape" => { description: "Shape", default: "1", format: "^([1-9]|[1-9][\\d]+)$|^([1-9]|[1-9][\\d]+)x([1-9]|[1-9][\\d]+)$|^([1-9]|[1-9][\\d]+)x([1-9]|[1-9][\\d]+)x([1-9]|[1-9][\\d]+)$"}
     }
 
     def validate_parameters(prm)

--- a/lib/xsub/schedulers/k.rb
+++ b/lib/xsub/schedulers/k.rb
@@ -22,11 +22,11 @@ LANG=C
 EOS
 
     PARAMETERS = {
-      "mpi_procs" => { description: "MPI process", default: 1},
-      "omp_threads" => { description: "OMP threads", default: 1},
-      "elapse" => { description: "Limit on elapsed time", default: "1:00:00"},
-      "node" => { description: "Nodes", default: "1"},
-      "shape" => { description: "Shape", default: "1"}
+      "mpi_procs" => { description: "MPI process", default: 1, format: "^([1-9]|[1-9][\\d]+)$"},
+      "omp_threads" => { description: "OMP threads", default: 1, format: "^([1-9]|[1-9][\\d]+)$"},
+      "elapse" => { description: "Limit on elapsed time", default: "1:00:00", format: "^([01]?[0-9]|2[0-4]):([0-5][\\d]):([0-5][\\d])$"},
+      "node" => { description: "Nodes", default: "1", format: "^([1-9]|[1-9][\\d]+)$|^([1-9]|[1-9][\\d]+)x([1-9]|[1-9][\\d]+)$|^([1-9]|[1-9][\\d]+)x([1-9]|[1-9][\\d]+)x([1-9]|[1-9][\\d]+)$"},
+      "shape" => { description: "Shape", default: "1", format: "^([1-9]|[1-9][\\d]+)$|^([1-9]|[1-9][\\d]+)x([1-9]|[1-9][\\d]+)$|^([1-9]|[1-9][\\d]+)x([1-9]|[1-9][\\d]+)x([1-9]|[1-9][\\d]+)$"}
     }
 
     def validate_parameters(prm)

--- a/lib/xsub/schedulers/torque.rb
+++ b/lib/xsub/schedulers/torque.rb
@@ -11,10 +11,10 @@ LANG=C
 EOS
 
     PARAMETERS = {
-      "mpi_procs" => { description: "MPI process", default: 1},
-      "omp_threads" => { description: "OMP threads", default: 1},
-      "ppn" => { description: "Process per nodes", default: 1},
-      "elapsed" => { description: "Limit on elapsed time", default: "1:00:00"}
+      "mpi_procs" => { description: "MPI process", default: 1, format: "^([1-9]|[1-9][\\d]+)$"},
+      "omp_threads" => { description: "OMP threads", default: 1, format: "^([1-9]|[1-9][\\d]+)$"},
+      "ppn" => { description: "Process per nodes", default: 1, format: "^([1-9]|[1-9][\\d]+)$"},
+      "elapse" => { description: "Limit on elapsed time", default: "1:00:00", format: "^[\\d]+:([0-5][\\d]):([0-5][\\d])$"}
     }
 
     def validate_parameters(prm)


### PR DESCRIPTION
### Problem
- Formats of host parameters are not appeared on xsub template.
### Solution
- Default formats for torque, fx10 and k scheduler are defined.
- (In OACS, host model is also updated to load formats from xsub template.)
