### PR TITLE
introduced github workflow instead of Travis

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,10 +3,10 @@ name: CI
 on:
   push:
     branches:
-      - main
+      - master
   pull_request:
     branches:
-      - main
+      - master
 
 jobs:
   build:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
 
     strategy:
       matrix:
-        ruby-version: ['2.7', '3.0']
+        ruby-version: ['2.7', '3.4']
 
     steps:
     - name: Checkout code

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,32 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        ruby-version: ['2.7', '3.0']
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v2
+
+    - name: Set up Ruby
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: ${{ matrix.ruby-version }}
+
+    - name: Install dependencies
+      run: bundle install
+
+    - name: Run tests
+      run: bundle exec rspec

--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
-[![Build Status](https://travis-ci.org/crest-cassia/xsub.svg?branch=master)](https://travis-ci.org/crest-cassia/xsub)
-[![Coverage Status](https://coveralls.io/repos/crest-cassia/xsub/badge.svg?branch=master&service=github)](https://coveralls.io/github/crest-cassia/xsub?branch=master)
+[![Build Status](https://github.com/crest-cassia/xsub/actions/workflows/ci.yml/badge.svg)](https://github.com/crest-cassia/xsub/actions/workflows/ci.yml)
 
 # xsub
 


### PR DESCRIPTION
This pull request includes changes to migrate the CI setup from Travis CI to GitHub Actions and update the build status badge in the `README.md` file accordingly.

CI setup migration:

* [`.github/workflows/ci.yml`](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fR1-R32): Added a new GitHub Actions workflow configuration to run CI on pushes and pull requests to the `main` branch, using Ruby versions 2.x and 3.x. The workflow includes steps to checkout code, set up Ruby, install dependencies, and run tests.

Documentation update:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L1-R1): Updated the build status badge to reflect the new CI setup using GitHub Actions instead of Travis CI.