### PR TITLE
check options param when submitting a job

### DIFF
--- a/lib/submitter.rb
+++ b/lib/submitter.rb
@@ -80,8 +80,11 @@ module Xsub
       end
 
       param_def.each do |key,definition|
-        unless @parameters[key].to_s =~ Regexp.new(definition[:format])
+        if definition[:format] and @parameters[key].to_s !~ Regexp.new(definition[:format])
           raise "invalid parameter format: #{key} #{@parameters[key]} #{definition[:format]}"
+        end
+        if definition[:options].is_a?(Array) and !definition[:options].include?(@parameters[key])
+          raise "invalid parameter value: #{key} #{@parameters[key]} #{definition[:options]}"
         end
       end
     end


### PR DESCRIPTION
This pull request includes changes to improve parameter validation in the `Submitter` class and adds corresponding tests to ensure the new functionality works correctly. The most important changes include modifying the `verify_parameter_format` method to check for valid parameter values and adding new test cases to `submitter_spec.rb`.

Improvements to parameter validation:

* [`lib/submitter.rb`](diffhunk://#diff-dbf4f13e51ede51215e507081f7c9e0ad8569a2ca0caf2fbfe807ac9c76debabL83-R88): Modified the `verify_parameter_format` method to include checks for both parameter format using regular expressions and valid parameter values from a predefined list of options.

Enhancements to test coverage:

* [`spec/submitter_spec.rb`](diffhunk://#diff-f2fdeb3a52ce6b8351ab325887f6f213df66dd714514793e31b557ad161160cfR105-R156): Added new test cases to check the format using regular expressions, skip the format check when a format is not provided, and raise an error when a parameter value is not included in the predefined options.